### PR TITLE
Reduce per-frame allocations: reuse emitter/order and reserve buffers in render state

### DIFF
--- a/perro_source/render_stack/perro_graphics/src/three_d/particles/gpu.rs
+++ b/perro_source/render_stack/perro_graphics/src/three_d/particles/gpu.rs
@@ -174,6 +174,7 @@ pub struct GpuPointParticles3D {
     compute_spawn_rings: AHashMap<NodeID, SpawnRingState>,
     compute_spawn_origin_dirty_slots: Vec<u32>,
     compute_spawn_rotation_dirty_slots: Vec<u32>,
+    emitter_order: Vec<usize>,
     spawn_origin_cache: AHashMap<NodeID, AHashMap<u32, SpawnOriginEntry>>,
     spawn_origin_generation: u64,
     hybrid_map_fingerprint: u64,
@@ -987,6 +988,7 @@ impl GpuPointParticles3D {
             compute_spawn_rings: AHashMap::new(),
             compute_spawn_origin_dirty_slots: Vec::new(),
             compute_spawn_rotation_dirty_slots: Vec::new(),
+            emitter_order: Vec::new(),
             spawn_origin_cache: AHashMap::new(),
             spawn_origin_generation: 0,
             hybrid_map_fingerprint: 0,
@@ -1041,9 +1043,16 @@ impl GpuPointParticles3D {
         if self.spawn_origin_generation == 0 {
             self.spawn_origin_generation = 1;
         }
-        let mut emitter_order = (0..frame.emitters.len()).collect::<Vec<_>>();
-        emitter_order.sort_unstable_by_key(|&i| frame.emitters[i].0.as_u64());
-        for idx in emitter_order {
+        self.emitter_order.clear();
+        if self.emitter_order.capacity() < frame.emitters.len() {
+            self.emitter_order
+                .reserve(frame.emitters.len() - self.emitter_order.capacity());
+        }
+        self.emitter_order.extend(0..frame.emitters.len());
+        self.emitter_order
+            .sort_unstable_by_key(|&i| frame.emitters[i].0.as_u64());
+        for pos in 0..self.emitter_order.len() {
+            let idx = self.emitter_order[pos];
             let (node, emitter) = &frame.emitters[idx];
             match emitter.sim_mode {
                 ParticleSimulationMode3D::Cpu => self.push_emitter_particles(*node, emitter),

--- a/perro_source/runtime_project/perro_runtime/src/runtime/render_bridge.rs
+++ b/perro_source/runtime_project/perro_runtime/src/runtime/render_bridge.rs
@@ -18,7 +18,6 @@ impl Runtime {
 
     pub fn drain_render_commands(&mut self, out: &mut Vec<RenderCommand>) {
         let mut queued_resource_commands = self.render.take_resource_queue_scratch();
-        queued_resource_commands.clear();
         self.resource_api
             .drain_commands(&mut queued_resource_commands);
         if !queued_resource_commands.is_empty() {

--- a/perro_source/runtime_project/perro_runtime/src/runtime/state.rs
+++ b/perro_source/runtime_project/perro_runtime/src/runtime/state.rs
@@ -229,6 +229,9 @@ impl RenderState {
     }
 
     pub(crate) fn drain_commands(&mut self, out: &mut Vec<RenderCommand>) {
+        if out.capacity() - out.len() < self.pending_commands.len() {
+            out.reserve(self.pending_commands.len() - (out.capacity() - out.len()));
+        }
         out.append(&mut self.pending_commands);
     }
 
@@ -587,6 +590,9 @@ impl DirtyState {
 
     pub(crate) fn take_pending_transform_roots(&mut self, out: &mut Vec<NodeID>) {
         out.clear();
+        if out.capacity() < self.pending_transform_roots.len() {
+            out.reserve(self.pending_transform_roots.len() - out.capacity());
+        }
         out.append(&mut self.pending_transform_roots);
         for id in out.iter().copied() {
             let index = id.index() as usize;


### PR DESCRIPTION
### Motivation

- Reduce frequent per-frame heap allocations and vector clears in particle preparation and render command draining to lower GC/allocator churn and improve runtime performance.

### Description

- Add an `emitter_order: Vec<usize>` field to `GpuPointParticles3D` and reuse it across frames instead of allocating a temporary `emitter_order` vector each `prepare` call.  
- Populate and sort `self.emitter_order` in `prepare` and iterate over it when pushing emitters, preserving capacity between frames.  
- Stop clearing the render resource scratch vector in `Runtime::drain_render_commands` so the pre-allocated scratch capacity can be reused by `resource_api::drain_commands`.  
- Add capacity reservations before `Vec::append` in `RenderState::drain_commands` and before appending pending transform roots in `DirtyState::take_pending_transform_roots` to avoid intermediate reallocations.

### Testing

- Built the workspace with `cargo build` to verify no compilation errors, and the build succeeded.  
- Ran the test suite with `cargo test` across affected crates to validate behavior, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc2b928ab08323806ba3e10ed6ac49)