### PR TITLE
Reuse traversal_seen scratch set and add render extract profiling

### DIFF
--- a/perro_source/runtime_project/perro_runtime/src/runtime.rs
+++ b/perro_source/runtime_project/perro_runtime/src/runtime.rs
@@ -132,6 +132,13 @@ pub struct RuntimeUiTiming {
     pub removed_nodes: u32,
 }
 
+#[cfg(feature = "profile")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct RuntimeRenderExtractProfile {
+    pub seed_nodes: u32,
+    pub affected_nodes: u32,
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct RuntimePhysicsStepTiming {
     pub pre_transforms: Duration,
@@ -146,6 +153,22 @@ pub(crate) struct RuntimePhysicsStepTiming {
 }
 
 impl Runtime {
+    #[cfg(feature = "profile")]
+    pub fn last_render_2d_extract_profile(&self) -> RuntimeRenderExtractProfile {
+        RuntimeRenderExtractProfile {
+            seed_nodes: self.render_2d.profile_last_seed_nodes,
+            affected_nodes: self.render_2d.profile_last_affected_nodes,
+        }
+    }
+
+    #[cfg(feature = "profile")]
+    pub fn last_render_3d_extract_profile(&self) -> RuntimeRenderExtractProfile {
+        RuntimeRenderExtractProfile {
+            seed_nodes: self.render_3d.profile_last_seed_nodes,
+            affected_nodes: self.render_3d.profile_last_affected_nodes,
+        }
+    }
+
     pub fn new() -> Self {
         Self {
             time: Timing {

--- a/perro_source/runtime_project/perro_runtime/src/runtime/render_2d.rs
+++ b/perro_source/runtime_project/perro_runtime/src/runtime/render_2d.rs
@@ -38,7 +38,14 @@ impl Runtime {
         if traversal_ids.is_empty() && bootstrap_scan {
             traversal_ids.extend(self.nodes.iter().map(|(id, _)| id));
         }
-        let mut traversal_seen: AHashSet<NodeID> = traversal_ids.iter().copied().collect();
+        #[cfg(feature = "profile")]
+        {
+            self.render_2d.profile_last_seed_nodes =
+                traversal_ids.len().min(u32::MAX as usize) as u32;
+        }
+        let mut traversal_seen = std::mem::take(&mut self.render_2d.traversal_seen);
+        traversal_seen.clear();
+        traversal_seen.extend(traversal_ids.iter().copied());
         let mut traversal_cursor = 0usize;
         while traversal_cursor < traversal_ids.len() {
             let node = traversal_ids[traversal_cursor];
@@ -116,8 +123,15 @@ impl Runtime {
         visible_now.clear();
         self.render_2d.visible_now = visible_now;
 
+        #[cfg(feature = "profile")]
+        {
+            self.render_2d.profile_last_affected_nodes =
+                traversal_ids.len().min(u32::MAX as usize) as u32;
+        }
         traversal_ids.clear();
         self.render_2d.traversal_ids = traversal_ids;
+        traversal_seen.clear();
+        self.render_2d.traversal_seen = traversal_seen;
     }
 
     fn emit_sprite_2d(

--- a/perro_source/runtime_project/perro_runtime/src/runtime/render_3d.rs
+++ b/perro_source/runtime_project/perro_runtime/src/runtime/render_3d.rs
@@ -64,9 +64,14 @@ impl Runtime {
         if traversal_ids.is_empty() && bootstrap_scan {
             traversal_ids.extend(self.nodes.iter().map(|(id, _)| id));
         }
-        let mut seed_seen: ahash::AHashSet<NodeID> = ahash::AHashSet::default();
-        traversal_ids.retain(|id| seed_seen.insert(*id));
-        let mut traversal_seen = seed_seen;
+        let mut traversal_seen = std::mem::take(&mut self.render_3d.traversal_seen);
+        traversal_seen.clear();
+        traversal_ids.retain(|id| traversal_seen.insert(*id));
+        #[cfg(feature = "profile")]
+        {
+            self.render_3d.profile_last_seed_nodes =
+                traversal_ids.len().min(u32::MAX as usize) as u32;
+        }
         let mut traversal_cursor = 0usize;
         while traversal_cursor < traversal_ids.len() {
             let node = traversal_ids[traversal_cursor];
@@ -78,6 +83,11 @@ impl Runtime {
                     }
                 }
             }
+        }
+        #[cfg(feature = "profile")]
+        {
+            self.render_3d.profile_last_affected_nodes =
+                traversal_ids.len().min(u32::MAX as usize) as u32;
         }
         let mut visible_now = std::mem::take(&mut self.render_3d.visible_now);
         visible_now.clear();
@@ -643,6 +653,8 @@ impl Runtime {
 
         traversal_ids.clear();
         self.render_3d.traversal_ids = traversal_ids;
+        traversal_seen.clear();
+        self.render_3d.traversal_seen = traversal_seen;
         skeleton_cache.clear();
         self.render_3d.skeleton_cache_scratch = skeleton_cache;
     }

--- a/perro_source/runtime_project/perro_runtime/src/runtime/state.rs
+++ b/perro_source/runtime_project/perro_runtime/src/runtime/state.rs
@@ -305,12 +305,17 @@ pub(crate) struct DirtyState {
 
 pub(crate) struct Render2DState {
     pub(crate) traversal_ids: Vec<NodeID>,
+    pub(crate) traversal_seen: AHashSet<NodeID>,
     pub(crate) visible_now: AHashSet<NodeID>,
     pub(crate) prev_visible: AHashSet<NodeID>,
     pub(crate) retained_sprites: AHashMap<NodeID, Sprite2DCommand>,
     pub(crate) texture_sources: AHashMap<NodeID, String>,
     pub(crate) last_camera: Option<perro_render_bridge::Camera2DState>,
     pub(crate) removed_nodes: Vec<NodeID>,
+    #[cfg(feature = "profile")]
+    pub(crate) profile_last_seed_nodes: u32,
+    #[cfg(feature = "profile")]
+    pub(crate) profile_last_affected_nodes: u32,
 }
 
 pub(crate) struct RenderUiState {
@@ -385,18 +390,24 @@ impl Render2DState {
     pub(crate) fn new() -> Self {
         Self {
             traversal_ids: Vec::new(),
+            traversal_seen: AHashSet::default(),
             visible_now: AHashSet::default(),
             prev_visible: AHashSet::default(),
             retained_sprites: AHashMap::default(),
             texture_sources: AHashMap::default(),
             last_camera: None,
             removed_nodes: Vec::new(),
+            #[cfg(feature = "profile")]
+            profile_last_seed_nodes: 0,
+            #[cfg(feature = "profile")]
+            profile_last_affected_nodes: 0,
         }
     }
 }
 
 pub(crate) struct Render3DState {
     pub(crate) traversal_ids: Vec<NodeID>,
+    pub(crate) traversal_seen: AHashSet<NodeID>,
     pub(crate) visible_now: AHashSet<NodeID>,
     pub(crate) prev_visible: AHashSet<NodeID>,
     pub(crate) mesh_sources: AHashMap<NodeID, String>,
@@ -415,12 +426,17 @@ pub(crate) struct Render3DState {
     pub(crate) skeleton_cache_scratch: AHashMap<NodeID, SkeletonPalette>,
     pub(crate) removed_nodes: Vec<NodeID>,
     pub(crate) force_full_scan_once: bool,
+    #[cfg(feature = "profile")]
+    pub(crate) profile_last_seed_nodes: u32,
+    #[cfg(feature = "profile")]
+    pub(crate) profile_last_affected_nodes: u32,
 }
 
 impl Render3DState {
     pub(crate) fn new() -> Self {
         Self {
             traversal_ids: Vec::new(),
+            traversal_seen: AHashSet::default(),
             visible_now: AHashSet::default(),
             prev_visible: AHashSet::default(),
             mesh_sources: AHashMap::default(),
@@ -439,6 +455,10 @@ impl Render3DState {
             skeleton_cache_scratch: AHashMap::default(),
             removed_nodes: Vec::new(),
             force_full_scan_once: false,
+            #[cfg(feature = "profile")]
+            profile_last_seed_nodes: 0,
+            #[cfg(feature = "profile")]
+            profile_last_affected_nodes: 0,
         }
     }
 }

--- a/perro_source/runtime_project/perro_runtime/tests/unit/runtime_hotpath_tests.rs
+++ b/perro_source/runtime_project/perro_runtime/tests/unit/runtime_hotpath_tests.rs
@@ -224,6 +224,39 @@ fn bench_transform_dirty_propagate_and_refresh() {
 
 #[test]
 #[ignore]
+fn bench_render_traversal_seen_reuse() {
+    use ahash::AHashSet;
+    let count = 80_000usize;
+    let rounds = 1_500usize;
+    let ids: Vec<NodeID> = (1..=count as u32).map(|i| NodeID::from_parts(i, 0)).collect();
+
+    let start_fresh = std::time::Instant::now();
+    let mut fresh_acc = 0usize;
+    for _ in 0..rounds {
+        let mut seen: AHashSet<NodeID> = ids.iter().copied().collect();
+        fresh_acc = fresh_acc.wrapping_add(seen.len());
+        seen.clear();
+    }
+    let fresh_us = start_fresh.elapsed().as_micros();
+
+    let mut scratch: AHashSet<NodeID> = AHashSet::default();
+    let start_reuse = std::time::Instant::now();
+    let mut reuse_acc = 0usize;
+    for _ in 0..rounds {
+        scratch.clear();
+        scratch.extend(ids.iter().copied());
+        reuse_acc = reuse_acc.wrapping_add(scratch.len());
+    }
+    let reuse_us = start_reuse.elapsed().as_micros();
+    let speedup = fresh_us as f64 / reuse_us.max(1) as f64;
+    println!(
+        "bench_render_traversal_seen_reuse: count={} rounds={} fresh_us={} reuse_us={} speedup={:.3}x fresh_acc={} reuse_acc={}",
+        count, rounds, fresh_us, reuse_us, speedup, fresh_acc, reuse_acc
+    );
+}
+
+#[test]
+#[ignore]
 fn bench_render_command_drain_hotloop() {
     let mut runtime = Runtime::new();
     let rounds = 80_000usize;


### PR DESCRIPTION
### Motivation
- Reduce allocations during 2D/3D render extraction by reusing a scratch `AHashSet` for traversal "seen" nodes.
- Record seed and affected node counts for render extraction to aid profiling when the `profile` feature is enabled.
- Provide accessors to obtain the last extraction profile from `Runtime` for diagnostics.

### Description
- Added a `traversal_seen: AHashSet<NodeID>` field to `Render2DState` and `Render3DState` and initialize it in their `new()` constructors.
- Modified 2D and 3D extraction paths to reuse the `traversal_seen` scratch set (take/clear/extend) instead of allocating a new `AHashSet` each frame and restored it to state at the end of extraction.
- Added `profile_last_seed_nodes` and `profile_last_affected_nodes` counters to `Render2DState` and `Render3DState` (gated by `#[cfg(feature = "profile")]`) and set them during extraction to record seed/affected sizes.
- Introduced a `RuntimeRenderExtractProfile` struct (gated by `profile`) and `Runtime` accessors `last_render_2d_extract_profile` and `last_render_3d_extract_profile` to expose the recorded counts.
- Added an ignored micro-benchmark test `bench_render_traversal_seen_reuse` to measure allocation vs reuse performance of the seen set.

### Testing
- Ran the unit test suite with `cargo test`, and existing tests completed successfully; the new benchmark test is marked `#[ignore]` and is not run by default.
- The micro-benchmark `bench_render_traversal_seen_reuse` can be executed with `cargo test -- --ignored` to observe fresh vs reuse timings and printed speedup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3796f5008323afda81bc7773778b)