### PR TITLE
Track gamepad index->id mapping and cache HidApi for JoyCon scanning

### DIFF
--- a/perro_source/render_stack/perro_app/src/input/gamepad.rs
+++ b/perro_source/render_stack/perro_app/src/input/gamepad.rs
@@ -49,6 +49,7 @@ mod backend {
     pub struct GamepadBackend {
         gilrs: Option<Gilrs>,
         id_to_uuid: HashMap<GamepadId, [u8; 16]>,
+        index_to_id: HashMap<usize, GamepadId>,
         uuid_to_index: HashMap<[u8; 16], usize>,
         index_to_uuid: Vec<Option<[u8; 16]>>,
         free_indices: Vec<usize>,
@@ -174,12 +175,7 @@ mod backend {
         }
 
         fn find_gamepad_id_by_index(&self, index: usize) -> Option<GamepadId> {
-            for (id, uuid) in &self.id_to_uuid {
-                if self.uuid_to_index.get(uuid).copied() == Some(index) {
-                    return Some(*id);
-                }
-            }
-            None
+            self.index_to_id.get(&index).copied()
         }
 
         fn ensure_gilrs(&mut self) {
@@ -364,6 +360,7 @@ mod backend {
             }
             self.uuid_in_use.insert(uuid);
             self.id_to_uuid.insert(id, uuid);
+            self.index_to_id.insert(index, id);
             Some(index)
         }
 
@@ -374,6 +371,7 @@ mod backend {
             let Some(index) = self.uuid_to_index.get(&uuid).copied() else {
                 return;
             };
+            self.index_to_id.remove(&index);
             if self.free_index_set.insert(index) {
                 self.free_indices.push(index);
             }

--- a/perro_source/render_stack/perro_app/src/input/joycon.rs
+++ b/perro_source/render_stack/perro_app/src/input/joycon.rs
@@ -143,6 +143,7 @@ mod backend {
 
     #[derive(Default)]
     pub struct JoyConBackend {
+        hid_api: Option<HidApi>,
         devices: HashMap<String, DeviceHandle>,
         slots: Arc<Mutex<SlotAllocator>>,
         rx: Option<Receiver<JoyConEvent>>,
@@ -214,7 +215,16 @@ mod backend {
             }
             self.last_scan = Some(now);
 
-            let Ok(api) = HidApi::new() else {
+            if self.hid_api.is_none() {
+                self.hid_api = HidApi::new().ok();
+            }
+            let Some(api) = self.hid_api.as_mut() else {
+                return;
+            };
+            if api.refresh_devices().is_err() {
+                self.hid_api = HidApi::new().ok();
+            }
+            let Some(api) = self.hid_api.as_ref() else {
                 return;
             };
 


### PR DESCRIPTION
### Motivation

- Ensure fast and reliable lookup of a `GamepadId` by persistent numerical index and keep mappings consistent when controllers connect/disconnect.
- Avoid repeatedly creating `HidApi` instances during JoyCon scans and handle device refresh failures more robustly.

### Description

- Added `index_to_id: HashMap<usize, GamepadId>` to `GamepadBackend` and updated `find_gamepad_id_by_index` to use it for O(1) lookup.
- Maintain `index_to_id` in `assign_index_if_unique` and remove entries in `handle_disconnect` so index/UUID/ID state stays consistent.
- Added `hid_api: Option<HidApi>` to `JoyConBackend` and changed `scan_if_needed` to cache the `HidApi` instance, call `refresh_devices()`, and gracefully recreate the API on error instead of failing immediately.

### Testing

- Built the project with `cargo build` successfully.
- Ran the test suite with `cargo test` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3ed333b883239c7c8a560f68b613)